### PR TITLE
docs: clarify container states and text serialization methods

### DIFF
--- a/pages/docs/advanced/cid.mdx
+++ b/pages/docs/advanced/cid.mdx
@@ -44,6 +44,51 @@ export type ContainerID =
      containers
    - Contains the Operation ID of its creation within its Container ID
 
+## Attached vs Detached Containers
+
+Containers in Loro exist in two states: **attached** and **detached**.
+
+### Detached Containers
+
+When you create a container directly using constructors like `new LoroMap()` or `new LoroText()`, the container is **detached**:
+
+- It has not been inserted into any document yet
+- Its ContainerID is a fixed default value
+- The actual ContainerID will be determined when it's inserted into a document
+
+### Attached Containers  
+
+When you get a container through the document API like `doc.getText("text")` or `map.setContainer("key", new LoroText())`, the container becomes **attached**:
+
+- It belongs to a specific document
+- It has a proper ContainerID determined by:
+  - **Root containers**: Named by the string parameter (e.g., "text" in `doc.getText("text")`)
+  - **Normal containers**: Based on the OpID at insertion time
+
+### Why This Matters
+
+The ContainerID is not a random UUID. It's deterministically generated:
+- Root-level containers derive their ID from their name
+- Nested containers derive their ID from the operation that created them
+
+This is why a detached container cannot have its final ContainerID until it's actually inserted into a document - we need the insertion context to generate the proper ID.
+
+```ts twoslash
+import { LoroDoc, LoroMap, LoroText } from "loro-crdt";
+// ---cut---
+// Detached container - has default ContainerID
+const detachedMap = new LoroMap();
+
+const doc = new LoroDoc();
+// Attached container - has proper ContainerID
+const attachedMap = doc.getMap("myMap");
+
+// Detached text becomes attached when inserted
+const detachedText = new LoroText();
+attachedMap.setContainer("text", detachedText);
+// Now detachedText is attached with a proper ContainerID
+```
+
 ## Container Overwrites
 
 When initializing child containers in parallel, overwrites can occur instead of

--- a/pages/docs/tutorial/text.mdx
+++ b/pages/docs/tutorial/text.mdx
@@ -316,10 +316,43 @@ const restored = Cursor.decode(bytes);
 const pos = doc.getCursorPos(restored);
 ```
 
+### `toJSON(): string`
+
+Returns the plain text content as a string. This method:
+- Returns only the text content without any formatting marks
+- Is not affected by any rich text attributes (bold, italic, links, etc.)
+- Is equivalent to `toString()` for text containers
+
+If you need rich text information including formatting, use `toDelta()` instead.
+
 ### `toDelta(): Delta<string>[]`
 
-Get the rich text value. It's in
+Get the rich text value with all formatting information. It's in
 [Quill's Delta format](https://quilljs.com/docs/delta/).
+
+Unlike `toJSON()` which returns plain text, `toDelta()` preserves all rich text attributes like bold, italic, links, and custom marks.
+
+Example comparing `toJSON()` vs `toDelta()`:
+
+```ts twoslash
+import { LoroDoc } from "loro-crdt";
+// ---cut---
+const doc = new LoroDoc();
+doc.configTextStyle({ bold: { expand: "after" } });
+const text = doc.getText("text");
+text.insert(0, "Hello World!");
+text.mark({ start: 0, end: 5 }, "bold", true);
+
+// toJSON returns plain string without marks
+console.log(text.toJSON()); // "Hello World!"
+
+// toDelta returns rich text with formatting
+console.log(text.toDelta());
+// [
+//   { insert: "Hello", attributes: { bold: true } },
+//   { insert: " World!" }
+// ]
+```
 
 ### `mark(range: {start: number, end: number}, key: string, value: any): void`
 


### PR DESCRIPTION
## Summary
- Added documentation explaining attached vs detached container states and their ContainerID behavior
- Clarified the difference between `toJSON()` (plain text) and `toDelta()` (rich text with formatting)
- Added examples demonstrating these concepts

## Changes
1. **cid.mdx**: Added new section "Attached vs Detached Containers" explaining:
   - How containers created with `new LoroMap()` are detached with default ContainerID
   - How containers from `doc.getText()` are attached with proper ContainerID
   - Why ContainerID generation requires insertion context

2. **text.mdx**: Added `toJSON()` method documentation:
   - Clarifies it returns plain string without formatting marks
   - Explains when to use `toJSON()` vs `toDelta()`
   - Includes comparison example showing the difference

## Test plan
- [ ] Review documentation changes for clarity
- [ ] Verify code examples are correct
- [ ] Check that the explanation aligns with actual Loro behavior

🤖 Generated with [Claude Code](https://claude.ai/code)