### PR TITLE
fix: LoroText.length is a property not a function

### DIFF
--- a/pages/docs/tutorial/text.mdx
+++ b/pages/docs/tutorial/text.mdx
@@ -237,7 +237,7 @@ Get the character at the given position.
 Delete and return the string at the given range and insert a string at the same
 position.
 
-### `length(): number`
+### `length: number`
 
 Get the length of text
 


### PR DESCRIPTION
The wasm binding has this as a `getter` so I'm assuming this is a docs issue because `.length` is a well established _property_ on JavaScript objects (see `String`, `Array`).