### PR TITLE
docs: clarify peer id reuse safeguards

### DIFF
--- a/pages/docs/concepts/peerid_management.mdx
+++ b/pages/docs/concepts/peerid_management.mdx
@@ -41,6 +41,8 @@ doc.setPeerId("123123123");  // You can only set 64 bit integers as peer IDs
 
 ⚠️ **Warning**: Manual assignment requires careful conflict avoidance.
 
+If you intentionally reuse a Peer ID, persist the document's local data (snapshot, updates, or durable cache) alongside that ID and load it before fetching or applying any remote updates. This ensures the `(peerId, counter)` pairs continue to reference the same operations. Skipping this step risks generating a new operation that reuses an existing operation ID, which leads to inconsistent replicas.
+
 ## Counter System
 
 Each peer maintains a monotonic counter starting at 0:
@@ -65,6 +67,7 @@ console.log(doc.version()); // { "1": 2 }
 - Use user IDs as peer IDs, because an user can have multiple devices
 - Use fixed IDs
 - Reuse IDs without proper management
+- Allow multiple browser tabs or processes to operate on the same reused Peer ID in parallel—coordinate access with locks so that only one session emits operations for that ID at a time
 
 ## Related Documentation
 

--- a/pages/docs/tutorial/tips.mdx
+++ b/pages/docs/tutorial/tips.mdx
@@ -20,6 +20,8 @@ from an identical baseline without generating unnecessary operations.
 
 When using `setPeerId`, you must avoid having two parallel peers use the same PeerId. This can cause serious consistency problems in your application.
 
+If you plan to reuse a PeerId across sessions, make sure that you persist the document's local state together with that PeerId and load it before applying any remote updates. Otherwise, the same `peerId + counter` combination could end up referring to two different operations, producing divergence that cannot be resolved automatically.
+
 <details>
 <summary>Why</summary>
 
@@ -33,6 +35,8 @@ It's because Loro determines whether an operation has already been included by c
 Be careful when reusing PeerIds (this optimization is often unnecessary). You should not assign a fixed PeerId to a user, as one user might use multiple devices. Similarly, you shouldn't assign a fixed PeerId to a device, because even on a single browser, multiple tabs might open the same document simultaneously.
 
 If you must reuse PeerIds, you need to carefully manage your local PeerId cache with proper locking mechanisms. This would allow only one tab to "take" a specific PeerId, while other tabs use random IDs. The PeerId should be returned to the cache when no longer in use.
+
+In addition to locking, avoid having multiple browser tabs (or apps on different processes) use the same PeerId concurrently. Coordinating access in this way ensures that a reused PeerId never emits two different operations with the same operation ID.
 
 </details>
 


### PR DESCRIPTION
## Summary
- document the need to persist and reload local data when reusing peer IDs
- highlight the dangers of sharing a reused peer ID across simultaneous sessions

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68f7a3fc055c832e8752167a19c8e844