### PR TITLE
Enable docs i18n with localized introduction pages

### DIFF
--- a/next.config.mjs
+++ b/next.config.mjs
@@ -9,6 +9,10 @@ const withNextra = nextra({
 });
 
 export default withNextra({
+  i18n: {
+    locales: ["en", "zh", "ja", "de", "fr"],
+    defaultLocale: "en",
+  },
     webpack(config, { isServer, dev }) {
       // Use the client static directory in the server bundle and prod mode
       // Fixes `Error occurred prerendering page "/"`

--- a/pages/docs/index.de.mdx
+++ b/pages/docs/index.de.mdx
@@ -1,0 +1,122 @@
+## Einführung in Loro
+
+Es ist allgemein bekannt, dass das Synchronisieren von Daten oder der Aufbau von Echtzeit-Collaboration-Apps herausfordernd ist – insbesondere, wenn Geräte offline sein können oder Teil eines Peer-to-Peer-Netzwerks sind. Loro vereinfacht diesen Prozess für dich.
+
+Wir möchten bessere Entwickler-Tools bereitstellen, damit das Erstellen von [Local-First-Apps](https://www.inkandswitch.com/local-first/) einfach und angenehm wird.
+
+Loro nutzt [Conflict-free Replicated Data Types (CRDTs)](/docs/concepts/crdt), um parallele Änderungen aufzulösen. Mit den Datentypen von Loro kannst du deine Anwendungen kollaborativ machen und den Bearbeitungsverlauf mit geringem Overhead behalten.
+
+Sobald du den Zustand deiner App mit Loro modelliert hast, ist das Synchronisieren ganz simpel:
+
+```ts twoslash
+import { LoroDoc } from "loro-crdt";
+const docA = new LoroDoc();
+const docB = new LoroDoc();
+docA.getText("text").insert(0, "Hello world!");
+docB.getText("text").insert(0, "Hi!");
+// Angenommen, docA und docB befinden sich auf zwei verschiedenen Geräten
+const bytesA = docA.export({ mode: "update" });
+// Sende bytes auf beliebige Weise an docB
+docB.import(bytesA);
+// docB enthält jetzt alle Änderungen von docA
+
+const bytesB = docB.export({ mode: "update" });
+// Sende bytes auf beliebige Weise an docA
+docA.import(bytesB);
+// docA und docB sind nun synchron und haben denselben Zustand
+```
+
+Das Speichern deines App-Zustands ist ebenso unkompliziert:
+
+```ts twoslash
+import { LoroDoc } from "loro-crdt";
+// ---cut---
+const doc = new LoroDoc();
+doc.getText("text").insert(0, "Hello world!");
+const bytes = doc.export({ mode: "snapshot" });
+// Bytes können im lokalen Speicher, in einer Datenbank oder über das Netzwerk gespeichert bzw. versendet werden
+```
+
+So lädst du deinen App-Zustand:
+
+```ts no_run twoslash
+import { LoroDoc } from "loro-crdt";
+const bytes = new Uint8Array([1, 2, 3]);
+// ---cut---
+const newDoc = new LoroDoc();
+newDoc.import(bytes);
+```
+
+Mit Loro kannst du außerdem ganz einfach in der Historie zurückspringen und deiner App Versionskontrolle hinzufügen. [Mehr über Time Travel erfahren](/docs/tutorial/time_travel).
+
+```ts no_run twoslash
+import { LoroDoc } from "loro-crdt";
+const doc = new LoroDoc();
+const version = doc.frontiers();
+// ---cut---
+doc.checkout(version); // Checke das Dokument auf die angegebene Version aus
+```
+
+Loro ist mit dem JSON-Schema kompatibel. Wenn du den Zustand deiner App mit JSON modellieren kannst, kannst du deine App sehr wahrscheinlich mit Loro synchronisieren. Da wir uns an das JSON-Schema halten müssen, dürfen Zahlen nicht als Schlüssel in einer Map verwendet werden, und zyklische Referenzen sollten vermieden werden.
+
+```ts no_run twoslash
+import { LoroDoc } from "loro-crdt";
+const doc = new LoroDoc();
+// ---cut---
+doc.toJSON(); // JSON-Darstellung des Dokuments abrufen
+```
+
+import { Cards } from "nextra/components";
+
+<Cards num={1}>
+  <Cards.Card
+    image
+    arrow
+    title="Erste Schritte"
+    href="/docs/tutorial/get_started"
+    style={{
+      maxWidth: 400,
+    }}
+  >
+    <>![Erste Schritte](/images/GettingStarted.png)</>
+  </Cards.Card>
+</Cards>
+
+## Ist Loro das Richtige für dich?
+
+### ✅ Verwende Loro, wenn du Folgendes brauchst:
+
+- Echtzeit-Zusammenarbeit an Dokumenten
+- Automatische Konfliktlösung bei parallelen Änderungen
+- Offline-Bearbeitung mit späterer Synchronisation
+- Vollständige Bearbeitungshistorie und Time Travel
+- Peer-to-Peer-Synchronisation
+
+### ⚠️ Ziehe Alternativen in Betracht, wenn:
+
+- deine Anwendung starke Konsistenz verlangt
+- deine Daten nicht JSON-ähnlich sind (z. B. große Binärdaten oder Medienstreams)
+- einfache Client-Server-Synchronisation ausreicht (z. B. grundlegende WebSockets)
+- deine Anwendung extrem empfindlich auf die Bundle-Größe reagiert (Loro-WASM-Binary ~970KB, gzipped)
+
+[Erfahre mehr darüber, wann du keine CRDTs verwenden solltest →](/docs/concepts/when_not_crdt)
+
+## Unterschiede zu anderen CRDT-Bibliotheken
+
+Die folgende Tabelle fasst die Funktionen von Loro zusammen, die in anderen CRDT-Bibliotheken möglicherweise fehlen.
+
+| Funktionen / wichtige Designentscheidungen                              | Loro | Diamond-types | Yjs         | Automerge |
+| :---------------------------------------------------------------------- | :--- | :------------ | :---------- | :-------- |
+| [Event Graph Walker](https://loro.dev/docs/advanced/replayable_event_graph) | ✅   | ✅ Inventor   | ❌          | ❌        |
+| Rich Text CRDT                                                          | ✅   | ❌            | ❌          | ✅        |
+| [Movable Tree](https://ieeexplore.ieee.org/document/9563274)            | ✅   | ❌            | ❌          | ❌ Inventor |
+| [Movable List](https://loro.dev/docs/tutorial/list)                     | ✅   | ❌            | ❌          | ❌ Inventor |
+| Time Travel                                                             | ✅   | ✅            | ✅[1]       | ✅        |
+| [Fugue](https://arxiv.org/abs/2305.00583) / maximale Nicht-Interleaving | ✅   | ✅            | ❌          | ❌        |
+| JSON Types                                                              | ✅   | ❓            | ✅          | ✅        |
+| Zusammenführen von Elementen im Speicher per Run-Length-Encoding        | ✅   | ✅            | ✅ Inventor | ❌        |
+| Byzantinische Fehlertoleranz                                            | ❌   | ❌            | ❌          | ✅        |
+| Versionskontrolle                                                       | ✅   | ❌            | ❌          | ✅        |
+
+- [1] Anders als andere Bibliotheken verlangt Yjs, dass Nutzer:innen einen Versionsvektor und eine Delete-Set speichern, um zu einem bestimmten Zeitpunkt zurückzukehren.
+- [Fugue](https://arxiv.org/abs/2305.00583) ist ein Text-/Listen-CRDT, das die Wahrscheinlichkeit von Interleaving-Anomalien minimieren kann.

--- a/pages/docs/index.fr.mdx
+++ b/pages/docs/index.fr.mdx
@@ -1,0 +1,122 @@
+## Introduction à Loro
+
+Il est bien connu que synchroniser des données ou créer des applications collaboratives en temps réel est complexe, surtout lorsque les appareils peuvent être hors ligne ou appartiennent à un réseau pair-à-pair. Loro simplifie ce processus pour vous.
+
+Nous voulons fournir de meilleurs outils pour que la création d'[applications local-first](https://www.inkandswitch.com/local-first/) soit simple et agréable.
+
+Loro utilise des [types de données répliqués sans conflit (CRDT)](/docs/concepts/crdt) pour résoudre les modifications parallèles. En utilisant les types de données de Loro, vos applications deviennent collaboratives tout en conservant l’historique des éditions avec une faible surcharge.
+
+Une fois que vous avez modélisé l’état de votre application avec Loro, la synchronisation devient très simple :
+
+```ts twoslash
+import { LoroDoc } from "loro-crdt";
+const docA = new LoroDoc();
+const docB = new LoroDoc();
+docA.getText("text").insert(0, "Hello world!");
+docB.getText("text").insert(0, "Hi!");
+// Supposons que docA et docB se trouvent sur deux appareils différents
+const bytesA = docA.export({ mode: "update" });
+// Envoyez bytes à docB par n'importe quel moyen
+docB.import(bytesA);
+// docB contient maintenant toutes les modifications de docA
+
+const bytesB = docB.export({ mode: "update" });
+// Envoyez bytes à docA par n'importe quel moyen
+docA.import(bytesB);
+// docA et docB sont désormais synchronisés et partagent le même état
+```
+
+Sauvegarder l’état de votre application est tout aussi simple :
+
+```ts twoslash
+import { LoroDoc } from "loro-crdt";
+// ---cut---
+const doc = new LoroDoc();
+doc.getText("text").insert(0, "Hello world!");
+const bytes = doc.export({ mode: "snapshot" });
+// Les bytes peuvent être stockés en local, dans une base de données ou envoyés sur le réseau
+```
+
+Charger l’état de votre application :
+
+```ts no_run twoslash
+import { LoroDoc } from "loro-crdt";
+const bytes = new Uint8Array([1, 2, 3]);
+// ---cut---
+const newDoc = new LoroDoc();
+newDoc.import(bytes);
+```
+
+Loro facilite aussi le voyage dans le temps de l’historique et l’ajout de contrôle de version à votre application. [En savoir plus sur le time travel](/docs/tutorial/time_travel).
+
+```ts no_run twoslash
+import { LoroDoc } from "loro-crdt";
+const doc = new LoroDoc();
+const version = doc.frontiers();
+// ---cut---
+doc.checkout(version); // Restaure le document à la version indiquée
+```
+
+Loro est compatible avec le schéma JSON. Si vous pouvez modéliser l’état de votre application avec JSON, vous pourrez probablement la synchroniser avec Loro. Comme nous devons respecter le schéma JSON, il est interdit d’utiliser un nombre comme clé dans une Map et il faut éviter les références cycliques.
+
+```ts no_run twoslash
+import { LoroDoc } from "loro-crdt";
+const doc = new LoroDoc();
+// ---cut---
+doc.toJSON(); // Obtient la représentation JSON du document
+```
+
+import { Cards } from "nextra/components";
+
+<Cards num={1}>
+  <Cards.Card
+    image
+    arrow
+    title="Démarrer"
+    href="/docs/tutorial/get_started"
+    style={{
+      maxWidth: 400,
+    }}
+  >
+    <>![Démarrer](/images/GettingStarted.png)</>
+  </Cards.Card>
+</Cards>
+
+## Loro est-il fait pour vous ?
+
+### ✅ Utilisez Loro lorsque vous avez besoin de :
+
+- Collaboration en temps réel sur des documents
+- Résolution automatique des conflits lors des éditions concurrentes
+- Édition hors ligne avec synchronisation ultérieure
+- Historique complet des modifications et voyage dans le temps
+- Capacités de synchronisation pair-à-pair
+
+### ⚠️ Envisagez une alternative lorsque :
+
+- Votre application exige une forte cohérence
+- Vos données ne ressemblent pas à du JSON (par exemple, de gros flux binaires/multimédia)
+- Une simple synchronisation client-serveur suffit (par exemple avec des WebSockets basiques)
+- Votre application est très sensible à la taille du bundle (binaire WASM de Loro ~970KB, gzippé)
+
+[En savoir plus sur les situations où il ne faut pas utiliser de CRDT →](/docs/concepts/when_not_crdt)
+
+## Différences avec d’autres bibliothèques CRDT
+
+Le tableau ci-dessous résume les fonctionnalités de Loro qui peuvent être absentes des autres bibliothèques CRDT.
+
+| Fonctionnalités / décisions de conception clés                           | Loro | Diamond-types | Yjs         | Automerge |
+| :---------------------------------------------------------------------- | :--- | :------------ | :---------- | :-------- |
+| [Event Graph Walker](https://loro.dev/docs/advanced/replayable_event_graph) | ✅   | ✅ Inventor   | ❌          | ❌        |
+| Rich Text CRDT                                                          | ✅   | ❌            | ❌          | ✅        |
+| [Movable Tree](https://ieeexplore.ieee.org/document/9563274)            | ✅   | ❌            | ❌          | ❌ Inventor |
+| [Movable List](https://loro.dev/docs/tutorial/list)                     | ✅   | ❌            | ❌          | ❌ Inventor |
+| Time Travel                                                             | ✅   | ✅            | ✅[1]       | ✅        |
+| [Fugue](https://arxiv.org/abs/2305.00583) / non-entrelacement maximal   | ✅   | ✅            | ❌          | ❌        |
+| JSON Types                                                              | ✅   | ❓            | ✅          | ✅        |
+| Fusion des éléments en mémoire via un encodage par plages               | ✅   | ✅            | ✅ Inventor | ❌        |
+| Tolérance aux pannes byzantines                                         | ❌   | ❌            | ❌          | ✅        |
+| Contrôle de version                                                     | ✅   | ❌            | ❌          | ✅        |
+
+- [1] Contrairement aux autres, Yjs nécessite de stocker un vecteur de version et un ensemble de suppressions pour revenir à un instant précis.
+- [Fugue](https://arxiv.org/abs/2305.00583) est un CRDT pour le texte et les listes qui minimise la probabilité d’anomalies d’entrelacement.

--- a/pages/docs/index.ja.mdx
+++ b/pages/docs/index.ja.mdx
@@ -1,0 +1,122 @@
+## Loro の紹介
+
+データの同期やリアルタイム協調アプリの構築は、デバイスがオフラインになったり P2P ネットワークに属したりする場合には特に難しいことがよく知られています。Loro はそのプロセスをシンプルにします。
+
+私たちは、[ローカルファーストアプリ](https://www.inkandswitch.com/local-first/)の開発を簡単で楽しいものにするために、より良い開発者ツールを提供したいと考えています。
+
+Loro は[コンフリクトフリー複製データ型（CRDT）](/docs/concepts/crdt)を用いて並行編集を解決します。Loro のデータ型を利用すると、アプリケーションにコラボレーション機能を持たせ、低いオーバーヘッドで編集履歴を保持できます。
+
+Loro でアプリの状態をモデリングした後は、同期はとても簡単です。
+
+```ts twoslash
+import { LoroDoc } from "loro-crdt";
+const docA = new LoroDoc();
+const docB = new LoroDoc();
+docA.getText("text").insert(0, "Hello world!");
+docB.getText("text").insert(0, "Hi!");
+// docA と docB が別々のデバイス上にあると仮定します
+const bytesA = docA.export({ mode: "update" });
+// 任意の方法で bytes を docB に送信します
+docB.import(bytesA);
+// docB には docA の変更がすべて反映されます
+
+const bytesB = docB.export({ mode: "update" });
+// 任意の方法で bytes を docA に送信します
+docA.import(bytesB);
+// docA と docB は同期され、同じ状態になります
+```
+
+アプリの状態を保存するのも同様に簡単です。
+
+```ts twoslash
+import { LoroDoc } from "loro-crdt";
+// ---cut---
+const doc = new LoroDoc();
+doc.getText("text").insert(0, "Hello world!");
+const bytes = doc.export({ mode: "snapshot" });
+// Bytes はローカルストレージやデータベースに保存したり、ネットワーク経由で送信できます
+```
+
+アプリの状態を読み込むには：
+
+```ts no_run twoslash
+import { LoroDoc } from "loro-crdt";
+const bytes = new Uint8Array([1, 2, 3]);
+// ---cut---
+const newDoc = new LoroDoc();
+newDoc.import(bytes);
+```
+
+Loro を使えば履歴のタイムトラベルやアプリへのバージョン管理の追加も簡単です。[タイムトラベルについて詳しく見る](/docs/tutorial/time_travel)。
+
+```ts no_run twoslash
+import { LoroDoc } from "loro-crdt";
+const doc = new LoroDoc();
+const version = doc.frontiers();
+// ---cut---
+doc.checkout(version); // 指定したバージョンにドキュメントをチェックアウト
+```
+
+Loro は JSON スキーマと互換性があります。アプリの状態を JSON で表現できるなら、おそらく Loro で同期できます。JSON スキーマに従う必要があるため、Map で数値キーを使用することはできず、循環参照は避けてください。
+
+```ts no_run twoslash
+import { LoroDoc } from "loro-crdt";
+const doc = new LoroDoc();
+// ---cut---
+doc.toJSON(); // ドキュメントの JSON 表現を取得
+```
+
+import { Cards } from "nextra/components";
+
+<Cards num={1}>
+  <Cards.Card
+    image
+    arrow
+    title="はじめに"
+    href="/docs/tutorial/get_started"
+    style={{
+      maxWidth: 400,
+    }}
+  >
+    <>![はじめに](/images/GettingStarted.png)</>
+  </Cards.Card>
+</Cards>
+
+## Loro はあなたに向いていますか？
+
+### ✅ 次のようなニーズがあるなら Loro を選びましょう：
+
+- ドキュメントのリアルタイム共同編集
+- 競合する編集の自動解決
+- オフライン編集と後での同期
+- 完全な編集履歴とタイムトラベル
+- P2P 同期機能
+
+### ⚠️ 次の場合は別のアプローチを検討してください：
+
+- アプリケーションが強い一貫性を必要とする
+- データが JSON 的な構造ではない（大きなバイナリ／メディアストリーミングなど）
+- シンプルなクライアント・サーバー同期で十分（基本的な WebSocket など）
+- パッケージサイズに非常に敏感（Loro WASM バイナリは gzip 後で約 970KB）
+
+[CRDT を使うべきでない場合について詳しく見る →](/docs/concepts/when_not_crdt)
+
+## 他の CRDT ライブラリとの違い
+
+以下の表は、他の CRDT ライブラリにはない可能性がある Loro の機能をまとめたものです。
+
+| 機能／主要な設計判断                                                   | Loro | Diamond-types | Yjs         | Automerge |
+| :---------------------------------------------------------------------- | :--- | :------------ | :---------- | :-------- |
+| [Event Graph Walker](https://loro.dev/docs/advanced/replayable_event_graph) | ✅   | ✅ Inventor   | ❌          | ❌        |
+| Rich Text CRDT                                                          | ✅   | ❌            | ❌          | ✅        |
+| [Movable Tree](https://ieeexplore.ieee.org/document/9563274)            | ✅   | ❌            | ❌          | ❌ Inventor |
+| [Movable List](https://loro.dev/docs/tutorial/list)                     | ✅   | ❌            | ❌          | ❌ Inventor |
+| Time Travel                                                             | ✅   | ✅            | ✅[1]       | ✅        |
+| [Fugue](https://arxiv.org/abs/2305.00583) / 最大非インタリーブ          | ✅   | ✅            | ❌          | ❌        |
+| JSON Types                                                              | ✅   | ❓            | ✅          | ✅        |
+| ランレングス圧縮によるメモリ内の要素結合                              | ✅   | ✅            | ✅ Inventor | ❌        |
+| ビザンチン耐性                                                          | ❌   | ❌            | ❌          | ✅        |
+| バージョン管理                                                         | ✅   | ❌            | ❌          | ✅        |
+
+- [1] 他のライブラリと異なり、Yjs では特定の時点に戻るためにバージョンベクターと削除セットを保持する必要があります。
+- [Fugue](https://arxiv.org/abs/2305.00583) はテキスト／リスト向けの CRDT で、インタリーブ異常の発生確率を最小化できます。

--- a/pages/docs/index.zh.mdx
+++ b/pages/docs/index.zh.mdx
@@ -1,0 +1,122 @@
+## Loro 简介
+
+众所周知，同步数据或构建实时协作应用是一项艰巨的任务，尤其当设备可能离线或处于点对点网络中时。Loro 可以为你简化这一过程。
+
+我们希望提供更好的开发者工具，让构建[本地优先应用](https://www.inkandswitch.com/local-first/)变得轻松而愉悦。
+
+Loro 使用[无冲突复制数据类型（CRDT）](/docs/concepts/crdt)来处理并发编辑。通过使用 Loro 的数据类型，你的应用可以实现协作，并以很小的开销保留编辑历史。
+
+当你用 Loro 建模应用状态后，同步就非常简单：
+
+```ts twoslash
+import { LoroDoc } from "loro-crdt";
+const docA = new LoroDoc();
+const docB = new LoroDoc();
+docA.getText("text").insert(0, "Hello world!");
+docB.getText("text").insert(0, "Hi!");
+// 假设 docA 和 docB 位于两台不同的设备
+const bytesA = docA.export({ mode: "update" });
+// 通过任意方式将 bytes 发送到 docB
+docB.import(bytesA);
+// docB 现在包含来自 docA 的全部更改
+
+const bytesB = docB.export({ mode: "update" });
+// 通过任意方式将 bytes 发送到 docA
+docA.import(bytesB);
+// docA 和 docB 现在已同步，拥有相同的状态
+```
+
+保存应用状态同样简单：
+
+```ts twoslash
+import { LoroDoc } from "loro-crdt";
+// ---cut---
+const doc = new LoroDoc();
+doc.getText("text").insert(0, "Hello world!");
+const bytes = doc.export({ mode: "snapshot" });
+// Bytes 可以保存到本地存储、数据库或通过网络传输
+```
+
+加载应用状态：
+
+```ts no_run twoslash
+import { LoroDoc } from "loro-crdt";
+const bytes = new Uint8Array([1, 2, 3]);
+// ---cut---
+const newDoc = new LoroDoc();
+newDoc.import(bytes);
+```
+
+Loro 还让你轻松回溯历史，为应用添加版本控制。[了解更多关于时间旅行](/docs/tutorial/time_travel)。
+
+```ts no_run twoslash
+import { LoroDoc } from "loro-crdt";
+const doc = new LoroDoc();
+const version = doc.frontiers();
+// ---cut---
+doc.checkout(version); // 将文档检出到指定版本
+```
+
+Loro 与 JSON 模型兼容。如果你可以用 JSON 来建模应用状态，就大概率可以使用 Loro 进行同步。由于需要遵循 JSON 模型，不允许在 Map 中使用数字作为键，并且应避免循环引用。
+
+```ts no_run twoslash
+import { LoroDoc } from "loro-crdt";
+const doc = new LoroDoc();
+// ---cut---
+doc.toJSON(); // 获取文档的 JSON 表示
+```
+
+import { Cards } from "nextra/components";
+
+<Cards num={1}>
+  <Cards.Card
+    image
+    arrow
+    title="快速开始"
+    href="/docs/tutorial/get_started"
+    style={{
+      maxWidth: 400,
+    }}
+  >
+    <>![快速开始](/images/GettingStarted.png)</>
+  </Cards.Card>
+</Cards>
+
+## Loro 适合你吗？
+
+### ✅ 当你需要以下能力时请选择 Loro：
+
+- 文档的实时协作
+- 并发编辑的自动冲突解决
+- 支持离线编辑并在稍后同步
+- 完整的编辑历史与时间旅行
+- 点对点同步能力
+
+### ⚠️ 在以下情况下可以考虑其他方案：
+
+- 你的应用需要强一致性
+- 数据不是类似 JSON 的结构（例如大型二进制/媒体流）
+- 简单的客户端-服务器同步已经足够（例如基础的 WebSocket）
+- 你的应用对包体积非常敏感（Loro WASM 二进制压缩后约 970KB）
+
+[了解更多何时不应使用 CRDT →](/docs/concepts/when_not_crdt)
+
+## 与其他 CRDT 库的区别
+
+下表总结了 Loro 的特性，这些特性在其他 CRDT 库中可能不存在。
+
+| 特性 / 重要设计决策                                                     | Loro | Diamond-types | Yjs         | Automerge |
+| :---------------------------------------------------------------------- | :--- | :------------ | :---------- | :-------- |
+| [Event Graph Walker](https://loro.dev/docs/advanced/replayable_event_graph) | ✅   | ✅ Inventor   | ❌          | ❌        |
+| Rich Text CRDT                                                          | ✅   | ❌            | ❌          | ✅        |
+| [Movable Tree](https://ieeexplore.ieee.org/document/9563274)            | ✅   | ❌            | ❌          | ❌ Inventor |
+| [Movable List](https://loro.dev/docs/tutorial/list)                     | ✅   | ❌            | ❌          | ❌ Inventor |
+| Time Travel                                                             | ✅   | ✅            | ✅[1]       | ✅        |
+| [Fugue](https://arxiv.org/abs/2305.00583) / 最大非交错                   | ✅   | ✅            | ❌          | ❌        |
+| JSON Types                                                              | ✅   | ❓            | ✅          | ✅        |
+| 内存中通过游程编码合并元素                                             | ✅   | ✅            | ✅ Inventor | ❌        |
+| 拜占庭容错能力                                                         | ❌   | ❌            | ❌          | ✅        |
+| 版本控制                                                               | ✅   | ❌            | ❌          | ✅        |
+
+- [1] 与其他库不同，Yjs 要求用户存储版本向量和删除集合，才能回到特定时间点。
+- [Fugue](https://arxiv.org/abs/2305.00583) 是一种文本/列表 CRDT，可最大程度减少交错异常的概率。

--- a/theme.config.jsx
+++ b/theme.config.jsx
@@ -39,6 +39,7 @@ export default {
   },
   head: () => {
     const config = useConfig();
+    const { locale } = useRouter();
     // Nextra v3 moves reserved fields like `title`, `description`, `image`
     // out of `frontMatter` into top-level config. Fallback to frontMatter for
     // older content that still sets them there.
@@ -60,7 +61,7 @@ export default {
         <meta name="msapplication-TileColor" content="#fff" />
         <meta name="theme-color" content="#fff" />
         <meta name="viewport" content="width=device-width, initial-scale=1.0" />
-        <meta httpEquiv="Content-Language" content="en" />
+        <meta httpEquiv="Content-Language" content={locale ?? "en"} />
         <meta name="description" content={metaDescription} />
         <meta name="og:description" content={metaDescription} />
         <meta name="twitter:card" content="summary_large_image" />
@@ -80,6 +81,13 @@ export default {
       titleTemplate: asPath === "/" ? undefined : "%s – Loro",
     };
   },
+  i18n: [
+    { locale: "en", name: "English" },
+    { locale: "zh", name: "简体中文" },
+    { locale: "ja", name: "日本語" },
+    { locale: "de", name: "Deutsch" },
+    { locale: "fr", name: "Français" },
+  ],
   sidebar: {
     defaultMenuCollapseLevel: 1,
     autoCollapse: true,


### PR DESCRIPTION
## Summary
- enable Next.js built-in i18n and expose locales in the docs theme
- add localized Introduction to Loro docs in Chinese, Japanese, German, and French

## Testing
- not run (docs changes only)


------
https://chatgpt.com/codex/tasks/task_e_68fffa47d184832e8b894e5e46ea2d9a