### PR TITLE
docs: add pure-Go loro-go to community implementations

### DIFF
--- a/pages/docs/tutorial/get_started.mdx
+++ b/pages/docs/tutorial/get_started.mdx
@@ -15,6 +15,7 @@ You can use Loro in your application by using:
 - You can also find a list of examples in
   [Loro examples in Deno](https://github.com/loro-dev/loro-examples-deno).
 - [`loro-go`](https://github.com/aholstenson/loro-go) Community-maintained Go package
+- [`loro-go`](https://github.com/Deln0r/loro-go) Community-maintained pure-Go package (no cgo)
 
 You can use [Loro Inspector](/docs/advanced/inspector) to debug and visualize the state and history of Loro documents.
 


### PR DESCRIPTION
As invited in discussion #1016, adding my independent pure-Go implementation of the Loro wire format to the Getting Started list.

There is already a `loro-go` entry (aholstenson's), which is cgo bindings over the Rust core via loro-ffi. Mine is a separate project: a pure-Go reading and writing of the Fast wire format with no cgo. I tagged it `pure-Go (no cgo)` to keep the two distinct. Happy to adjust the wording if you prefer a different label.